### PR TITLE
Add IPv6 Support

### DIFF
--- a/cmd/curl.go
+++ b/cmd/curl.go
@@ -35,7 +35,7 @@ var (
 			if err != nil {
 				return err
 			}
-			return chkRunError(runCurl(c, args[0], curlHead, curlInsecure, curlHTTP2, from, nodeIDs, curlLimit, fileOut))
+			return chkRunError(runCurl(c, args[0], curlHead, curlInsecure, curlHTTP2, from, nodeIDs, curlLimit, fileOut, curlIpv6))
 		},
 	}
 
@@ -44,6 +44,7 @@ var (
 	curlHTTP2    bool
 	curlLimit    int
 	fileOut      string
+	curlIpv6     bool
 )
 
 func initCurlCmd(parentCmd *cobra.Command) {
@@ -54,21 +55,27 @@ func initCurlCmd(parentCmd *cobra.Command) {
 	curlCmd.Flags().BoolVarP(&curlHTTP2, "http2", "", false, "Use HTTP version 2")
 	curlCmd.Flags().IntVarP(&curlLimit, "limit", "L", 1, "The maximum number of nodes to use")
 	curlCmd.Flags().StringVarP(&fileOut, "file", "f", "", "output to file")
+	curlCmd.Flags().BoolVarP(&curlIpv6, "ipv6", "6", false, "Use IPv6")
 
 	parentCmd.AddCommand(curlCmd)
 }
 
-func runCurl(c *perfops.Client, target string, head, insecure, http2 bool, from string, nodeIDs []int, limit int, fileOut string) error {
+func runCurl(c *perfops.Client, target string, head, insecure, http2 bool, from string, nodeIDs []int, limit int, fileOut string, ipv6 bool) error {
 
 	ctx := context.Background()
+	ipversion := 4
+	if ipv6 {
+		ipversion = 6
+	}
 	curlReq := &perfops.CurlRequest{
-		Target:   target,
-		Head:     head,
-		Insecure: insecure,
-		HTTP2:    http2,
-		Location: from,
-		Nodes:    nodeIDs,
-		Limit:    limit,
+		Target:    target,
+		Head:      head,
+		Insecure:  insecure,
+		HTTP2:     http2,
+		Location:  from,
+		Nodes:     nodeIDs,
+		Limit:     limit,
+		IPVersion: ipversion,
 	}
 
 	f := internal.NewFormatter(debug && !outputJSON)

--- a/cmd/curl_test.go
+++ b/cmd/curl_test.go
@@ -35,6 +35,7 @@ func TestInitCurlCmd(t *testing.T) {
 		"insecure": {[]string{"--insecure"}, func() (interface{}, interface{}) { return curlInsecure, true }},
 		"http2":    {[]string{"--http2"}, func() (interface{}, interface{}) { return curlHTTP2, true }},
 		"limit":    {[]string{"--limit", "23"}, func() (interface{}, interface{}) { return curlLimit, 23 }},
+		"ipv6":     {[]string{"--ipv6"}, func() (interface{}, interface{}) { return curlIpv6, true }},
 	}
 	parent := &cobra.Command{}
 	for name, tc := range testCases {
@@ -63,15 +64,17 @@ func TestRunCurlResolve(t *testing.T) {
 		head     bool
 		insecure bool
 		http2    bool
+		ipv6     bool
 		from     string
 		nodeIDs  []int
 		exp      string
 	}{
-		"Head":     {false, false, false, "From here", []int{}, `{"target":"example.com","head":false,"location":"From here","limit":12}`},
-		"Insecure": {true, true, false, "From here", []int{}, `{"target":"example.com","head":true,"insecure":true,"location":"From here","limit":12}`},
-		"HTTP2":    {true, false, true, "From here", []int{}, `{"target":"example.com","head":true,"http2":true,"location":"From here","limit":12}`},
-		"Location": {true, false, false, "From here", []int{}, `{"target":"example.com","head":true,"location":"From here","limit":12}`},
-		"NodeID":   {true, false, false, "", []int{123}, `{"target":"example.com","head":true,"nodes":"123","limit":12}`},
+		"Head":     {false, false, false, false, "From here", []int{}, `{"target":"example.com","head":false,"location":"From here","limit":12,"ipversion":4}`},
+		"Insecure": {true, true, false, false, "From here", []int{}, `{"target":"example.com","head":true,"insecure":true,"location":"From here","limit":12,"ipversion":4}`},
+		"HTTP2":    {true, false, true, false, "From here", []int{}, `{"target":"example.com","head":true,"http2":true,"location":"From here","limit":12,"ipversion":4}`},
+		"Location": {true, false, false, false, "From here", []int{}, `{"target":"example.com","head":true,"location":"From here","limit":12,"ipversion":4}`},
+		"NodeID":   {true, false, false, false, "", []int{123}, `{"target":"example.com","head":true,"nodes":"123","limit":12,"ipversion":4}`},
+		"IPv6":     {false, false, false, true, "", []int{}, `{"target":"example.com","head":false,"limit":12,"ipversion":6}`},
 	}
 	// We're only interested in the first HTTP call, e.g., the one to get the test ID
 	// to validate our parameters got passed properly.
@@ -82,7 +85,7 @@ func TestRunCurlResolve(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			runCurl(c, "example.com", tc.head, tc.insecure, tc.http2, tc.from, tc.nodeIDs, 12, "file.txt")
+			runCurl(c, "example.com", tc.head, tc.insecure, tc.http2, tc.from, tc.nodeIDs, 12, "file.txt", tc.ipv6)
 			if got, exp := tr.req.URL.Path, "/run/curl"; got != exp {
 				t.Fatalf("expected %v; got %v", exp, got)
 			}

--- a/cmd/dnsperf.go
+++ b/cmd/dnsperf.go
@@ -36,12 +36,13 @@ var (
 			if err != nil {
 				return err
 			}
-			return chkRunError(runDNSPerf(c, args[0], dnsPerfDNSServer, from, nodeIDs, dnsPerfLimit))
+			return chkRunError(runDNSPerf(c, args[0], dnsPerfDNSServer, from, nodeIDs, dnsPerfLimit, dnsPerfIpv6))
 		},
 	}
 
 	dnsPerfDNSServer string
 	dnsPerfLimit     int
+	dnsPerfIpv6      bool
 )
 
 func initDNSPerfCmd(parentCmd *cobra.Command) {
@@ -49,18 +50,24 @@ func initDNSPerfCmd(parentCmd *cobra.Command) {
 
 	dnsPerfCmd.Flags().StringVarP(&dnsPerfDNSServer, "dns-server", "S", "", "The DNS server to use to query for the test. You can use 127.0.0.1 to use the local resolver for location based benchmarking.")
 	dnsPerfCmd.Flags().IntVarP(&dnsPerfLimit, "limit", "L", 1, "The maximum number of nodes to use")
+	dnsPerfCmd.Flags().BoolVarP(&dnsPerfIpv6, "ipv6", "6", false, "Use IPv6")
 
 	parentCmd.AddCommand(dnsPerfCmd)
 }
 
-func runDNSPerf(c *perfops.Client, target, dnsServer, from string, nodeIDs []int, limit int) error {
+func runDNSPerf(c *perfops.Client, target, dnsServer, from string, nodeIDs []int, limit int, ipv6 bool) error {
 	ctx := context.Background()
+	ipversion := 4
+	if ipv6 {
+		ipversion = 6
+	}
 	dnsPerfReq := &perfops.DNSPerfRequest{
 		Target:    target,
 		DNSServer: dnsServer,
 		Location:  from,
 		Nodes:     nodeIDs,
 		Limit:     limit,
+		IPVersion: ipversion,
 	}
 
 	spinner := internal.NewSpinner()

--- a/cmd/internal/runtest.go
+++ b/cmd/internal/runtest.go
@@ -58,12 +58,13 @@ type (
 )
 
 // RunTest runs an MTR or ping test retrieves its output and presents it to the user.
-func RunTest(ctx context.Context, target, location string, nodeIDs []int, limit int, debug, outputJSON bool, runTest runFunc, runOutput runOutputFunc) error {
+func RunTest(ctx context.Context, target, location string, nodeIDs []int, limit int, ipversion int, debug, outputJSON bool, runTest runFunc, runOutput runOutputFunc) error {
 	runReq := &perfops.RunRequest{
-		Target:   target,
-		Location: location,
-		Nodes:    nodeIDs,
-		Limit:    limit,
+		Target:    target,
+		Location:  location,
+		Nodes:     nodeIDs,
+		Limit:     limit,
+		IPVersion: ipversion,
 	}
 
 	f := NewFormatter(debug && !outputJSON)

--- a/cmd/internal/runtest_test.go
+++ b/cmd/internal/runtest_test.go
@@ -65,7 +65,7 @@ func TestRunTest(t *testing.T) {
 	ctx := context.Background()
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := RunTest(ctx, "target", "location", []int{}, 1, false, false, tc.run, tc.output)
+			err := RunTest(ctx, "target", "location", []int{}, 1, 4, false, false, tc.run, tc.output)
 			if err != tc.err {
 				t.Fatalf("expected %v; got %v", tc.err, err)
 			}

--- a/cmd/latency.go
+++ b/cmd/latency.go
@@ -34,20 +34,26 @@ var (
 			if err != nil {
 				return err
 			}
-			return chkRunError(runLatency(c, args[0], from, nodeIDs, latencyLimit))
+			return chkRunError(runLatency(c, args[0], from, nodeIDs, latencyLimit, latencyIpv6))
 		},
 	}
 
 	latencyLimit int
+	latencyIpv6  bool
 )
 
 func initLatencyCmd(parentCmd *cobra.Command) {
 	addCommonFlags(latencyCmd)
 	parentCmd.AddCommand(latencyCmd)
 	latencyCmd.Flags().IntVarP(&latencyLimit, "limit", "L", 1, "The maximum number of nodes to use")
+	latencyCmd.Flags().BoolVarP(&latencyIpv6, "ipv6", "6", false, "Use IPv6")
 }
 
-func runLatency(c *perfops.Client, target, from string, nodeIDs []int, limit int) error {
+func runLatency(c *perfops.Client, target, from string, nodeIDs []int, limit int, ipv6 bool) error {
 	ctx := context.Background()
-	return internal.RunTest(ctx, target, from, nodeIDs, limit, debug, outputJSON, c.Run.Latency, c.Run.LatencyOutput)
+	ipversion := 4
+	if ipv6 {
+		ipversion = 6
+	}
+	return internal.RunTest(ctx, target, from, nodeIDs, limit, ipversion, debug, outputJSON, c.Run.Latency, c.Run.LatencyOutput)
 }

--- a/cmd/latency_test.go
+++ b/cmd/latency_test.go
@@ -31,6 +31,7 @@ func TestInitLatencyCmd(t *testing.T) {
 		"json":   {[]string{"--json"}, func() (interface{}, interface{}) { return outputJSON, true }},
 
 		"limit": {[]string{"--limit", "23"}, func() (interface{}, interface{}) { return latencyLimit, 23 }},
+		"ipv6":  {[]string{"--ipv6"}, func() (interface{}, interface{}) { return latencyIpv6, true }},
 	}
 	parent := &cobra.Command{}
 	for name, tc := range testCases {
@@ -40,13 +41,13 @@ func TestInitLatencyCmd(t *testing.T) {
 			if err := latencyCmd.ParseFlags(tc.args); err != nil {
 				t.Fatalf("exepected nil; got %v", err)
 			}
-			flags := dnsPerfCmd.Flags()
+			flags := latencyCmd.Flags()
 			f := flags.Lookup(name)
 			if f == nil {
 				t.Fatal("expected flag; got nil")
 			}
 
-			got, exp := tc.gotexp();
+			got, exp := tc.gotexp()
 			if reflect.DeepEqual(got, exp) == false {
 				t.Fatalf("expected %v; got %v", exp, got)
 			}
@@ -58,10 +59,12 @@ func TestRunLatency(t *testing.T) {
 	testCases := map[string]struct {
 		from    string
 		nodeIDs []int
+		ipv6    bool
 		exp     string
 	}{
-		"Location": {"From here", []int{}, `{"target":"example.com","location":"From here","limit":12}`},
-		"NodeID":   {"", []int{123}, `{"target":"example.com","nodes":"123","limit":12}`},
+		"Location": {"From here", []int{}, false, `{"target":"example.com","location":"From here","limit":12,"ipversion":4}`},
+		"NodeID":   {"", []int{123}, false, `{"target":"example.com","nodes":"123","limit":12,"ipversion":4}`},
+		"IPv6":     {"", []int{}, true, `{"target":"example.com","limit":12,"ipversion":6}`},
 	}
 	// We're only interested in the first HTTP call, e.g., the one to get the test ID
 	// to validate our parameters got passed properly.
@@ -72,7 +75,7 @@ func TestRunLatency(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			runLatency(c, "example.com", tc.from, tc.nodeIDs, 12)
+			runLatency(c, "example.com", tc.from, tc.nodeIDs, 12, tc.ipv6)
 			if got, exp := tr.req.URL.Path, "/run/latency"; got != exp {
 				t.Fatalf("expected %v; got %v", exp, got)
 			}

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -34,20 +34,26 @@ var (
 			if err != nil {
 				return err
 			}
-			return chkRunError(runMTR(c, args[0], from, nodeIDs, mtrLimit))
+			return chkRunError(runMTR(c, args[0], from, nodeIDs, mtrLimit, mtrIpv6))
 		},
 	}
 
 	mtrLimit int
+	mtrIpv6  bool
 )
 
 func initMTRCmd(parentCmd *cobra.Command) {
 	addCommonFlags(mtrCmd)
 	mtrCmd.Flags().IntVarP(&mtrLimit, "limit", "L", 1, "The maximum number of nodes to use")
+	mtrCmd.Flags().BoolVarP(&mtrIpv6, "ipv6", "6", false, "Use IPv6")
 	parentCmd.AddCommand(mtrCmd)
 }
 
-func runMTR(c *perfops.Client, target, from string, nodeIDs []int, limit int) error {
+func runMTR(c *perfops.Client, target, from string, nodeIDs []int, limit int, ipv6 bool) error {
 	ctx := context.Background()
-	return internal.RunTest(ctx, target, from, nodeIDs, limit, debug, outputJSON, c.Run.MTR, c.Run.MTROutput)
+	ipversion := 4
+	if ipv6 {
+		ipversion = 6
+	}
+	return internal.RunTest(ctx, target, from, nodeIDs, limit, ipversion, debug, outputJSON, c.Run.MTR, c.Run.MTROutput)
 }

--- a/cmd/mtr_test.go
+++ b/cmd/mtr_test.go
@@ -31,6 +31,7 @@ func TestInitMTRCmd(t *testing.T) {
 		"json":   {[]string{"--json"}, func() (interface{}, interface{}) { return outputJSON, true }},
 
 		"limit": {[]string{"--limit", "23"}, func() (interface{}, interface{}) { return mtrLimit, 23 }},
+		"ipv6":  {[]string{"--ipv6"}, func() (interface{}, interface{}) { return mtrIpv6, true }},
 	}
 	parent := &cobra.Command{}
 	for name, tc := range testCases {
@@ -46,7 +47,7 @@ func TestInitMTRCmd(t *testing.T) {
 				t.Fatal("expected flag; got nil")
 			}
 
-			got, exp := tc.gotexp();
+			got, exp := tc.gotexp()
 			if reflect.DeepEqual(got, exp) == false {
 				t.Fatalf("expected %v; got %v", exp, got)
 			}
@@ -58,10 +59,12 @@ func TestRunMTR(t *testing.T) {
 	testCases := map[string]struct {
 		from    string
 		nodeIDs []int
+		ipv6    bool
 		exp     string
 	}{
-		"Location": {"From here", []int{}, `{"target":"example.com","location":"From here","limit":12}`},
-		"NodeID":   {"", []int{123}, `{"target":"example.com","nodes":"123","limit":12}`},
+		"Location": {"From here", []int{}, false, `{"target":"example.com","location":"From here","limit":12,"ipversion":4}`},
+		"NodeID":   {"", []int{123}, false, `{"target":"example.com","nodes":"123","limit":12,"ipversion":4}`},
+		"IPV6":     {"", []int{}, true, `{"target":"example.com","limit":12,"ipversion":6}`},
 	}
 	// We're only interested in the first HTTP call, e.g., the one to get the test ID
 	// to validate our parameters got passed properly.
@@ -72,7 +75,7 @@ func TestRunMTR(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			runMTR(c, "example.com", tc.from, tc.nodeIDs, 12)
+			runMTR(c, "example.com", tc.from, tc.nodeIDs, 12, tc.ipv6)
 			if got, exp := tr.req.URL.Path, "/run/mtr"; got != exp {
 				t.Fatalf("expected %v; got %v", exp, got)
 			}

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -34,20 +34,26 @@ var (
 			if err != nil {
 				return err
 			}
-			return chkRunError(runPing(c, args[0], from, nodeIDs, pingLimit))
+			return chkRunError(runPing(c, args[0], from, nodeIDs, pingLimit, pingIpv6))
 		},
 	}
 
 	pingLimit int
+	pingIpv6  bool
 )
 
 func initPingCmd(parentCmd *cobra.Command) {
 	addCommonFlags(pingCmd)
 	pingCmd.Flags().IntVarP(&pingLimit, "limit", "L", 1, "The maximum number of nodes to use")
+	pingCmd.Flags().BoolVarP(&pingIpv6, "ipv6", "6", false, "Use IPv6")
 	parentCmd.AddCommand(pingCmd)
 }
 
-func runPing(c *perfops.Client, target, from string, nodeIDs []int, limit int) error {
+func runPing(c *perfops.Client, target, from string, nodeIDs []int, limit int, ipv6 bool) error {
 	ctx := context.Background()
-	return internal.RunTest(ctx, target, from, nodeIDs, limit, debug, outputJSON, c.Run.Ping, c.Run.PingOutput)
+	ipversion := 4
+	if ipv6 {
+		ipversion = 6
+	}
+	return internal.RunTest(ctx, target, from, nodeIDs, limit, ipversion, debug, outputJSON, c.Run.Ping, c.Run.PingOutput)
 }

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -46,7 +46,7 @@ func TestInitPingCmd(t *testing.T) {
 				t.Fatal("expected flag; got nil")
 			}
 
-			got, exp := tc.gotexp();
+			got, exp := tc.gotexp()
 			if reflect.DeepEqual(got, exp) == false {
 				t.Fatalf("expected %v; got %v", exp, got)
 			}
@@ -58,10 +58,12 @@ func TestRunPing(t *testing.T) {
 	testCases := map[string]struct {
 		from    string
 		nodeIDs []int
+		ipv6    bool
 		exp     string
 	}{
-		"Location": {"From here", []int{}, `{"target":"example.com","location":"From here","limit":12}`},
-		"NodeID":   {"", []int{123}, `{"target":"example.com","nodes":"123","limit":12}`},
+		"Location": {"From here", []int{}, false, `{"target":"example.com","location":"From here","limit":12,"ipversion":4}`},
+		"NodeID":   {"", []int{123}, false, `{"target":"example.com","nodes":"123","limit":12,"ipversion":4}`},
+		"IPv6":     {"", []int{}, true, `{"target":"example.com","limit":12,"ipversion":6}`},
 	}
 	// We're only interested in the first HTTP call, e.g., the one to get the test ID
 	// to validate our parameters got passed properly.
@@ -72,7 +74,7 @@ func TestRunPing(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			runPing(c, "example.com", tc.from, tc.nodeIDs, 12)
+			runPing(c, "example.com", tc.from, tc.nodeIDs, 12, tc.ipv6)
 			if got, exp := tr.req.URL.Path, "/run/ping"; got != exp {
 				t.Fatalf("expected %v; got %v", exp, got)
 			}

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -34,20 +34,26 @@ var (
 			if err != nil {
 				return err
 			}
-			return chkRunError(runTraceroute(c, args[0], from, nodeIDs, tracerouteLimit))
+			return chkRunError(runTraceroute(c, args[0], from, nodeIDs, tracerouteLimit, tracerouteIpv6))
 		},
 	}
 
 	tracerouteLimit int
+	tracerouteIpv6  bool
 )
 
 func initTracerouteCmd(parentCmd *cobra.Command) {
 	addCommonFlags(tracerouteCmd)
 	tracerouteCmd.Flags().IntVarP(&tracerouteLimit, "limit", "L", 1, "The maximum number of nodes to use")
+	tracerouteCmd.Flags().BoolVarP(&tracerouteIpv6, "ipv6", "6", false, "Use IPv6")
 	parentCmd.AddCommand(tracerouteCmd)
 }
 
-func runTraceroute(c *perfops.Client, target, from string, nodeIDs []int, limit int) error {
+func runTraceroute(c *perfops.Client, target, from string, nodeIDs []int, limit int, ipv6 bool) error {
 	ctx := context.Background()
-	return internal.RunTest(ctx, target, from, nodeIDs, limit, debug, outputJSON, c.Run.Traceroute, c.Run.TracerouteOutput)
+	ipversion := 4
+	if ipv6 {
+		ipversion = 6
+	}
+	return internal.RunTest(ctx, target, from, nodeIDs, limit, ipversion, debug, outputJSON, c.Run.Traceroute, c.Run.TracerouteOutput)
 }

--- a/cmd/traceroute_test.go
+++ b/cmd/traceroute_test.go
@@ -31,6 +31,7 @@ func TestInitTracerouteCmd(t *testing.T) {
 		"json":   {[]string{"--json"}, func() (interface{}, interface{}) { return outputJSON, true }},
 
 		"limit": {[]string{"--limit", "23"}, func() (interface{}, interface{}) { return tracerouteLimit, 23 }},
+		"ipv6":  {[]string{"--ipv6"}, func() (interface{}, interface{}) { return tracerouteIpv6, true }},
 	}
 	parent := &cobra.Command{}
 	for name, tc := range testCases {
@@ -46,7 +47,7 @@ func TestInitTracerouteCmd(t *testing.T) {
 				t.Fatal("expected flag; got nil")
 			}
 
-			got, exp := tc.gotexp();
+			got, exp := tc.gotexp()
 			if reflect.DeepEqual(got, exp) == false {
 				t.Fatalf("expected %v; got %v", exp, got)
 			}
@@ -58,10 +59,12 @@ func TestRunTraceroute(t *testing.T) {
 	testCases := map[string]struct {
 		from    string
 		nodeIDs []int
+		ipv6    bool
 		exp     string
 	}{
-		"Location": {"From here", []int{}, `{"target":"example.com","location":"From here","limit":12}`},
-		"NodeID":   {"", []int{123}, `{"target":"example.com","nodes":"123","limit":12}`},
+		"Location": {"From here", []int{}, false, `{"target":"example.com","location":"From here","limit":12,"ipversion":4}`},
+		"NodeID":   {"", []int{123}, false, `{"target":"example.com","nodes":"123","limit":12,"ipversion":4}`},
+		"IPV6":     {"", []int{}, true, `{"target":"example.com","limit":12,"ipversion":6}`},
 	}
 	// We're only interested in the first HTTP call, e.g., the one to get the test ID
 	// to validate our parameters got passed properly.
@@ -72,7 +75,7 @@ func TestRunTraceroute(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			runTraceroute(c, "example.com", tc.from, tc.nodeIDs, 12)
+			runTraceroute(c, "example.com", tc.from, tc.nodeIDs, 12, tc.ipv6)
 			if got, exp := tr.req.URL.Path, "/run/traceroute"; got != exp {
 				t.Fatalf("expected %v; got %v", exp, got)
 			}

--- a/perfops/client.go
+++ b/perfops/client.go
@@ -29,7 +29,7 @@ import (
 const UserAgent = "PerfOps API Go Client"
 
 const (
-	apiRoot    = "https://api.perfops.net"
+	apiRoot    = "https://api.perfops.space"
 	basePath   = apiRoot
 	libVersion = "v1.0.0"
 	userAgent  = UserAgent + "/" + libVersion + " (" + runtime.GOOS + "/" + runtime.GOARCH + ")"
@@ -124,7 +124,7 @@ func NewClient(opts ...func(c *Client) error) (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) DoRequest(req *http.Request, v interface{}) (error) {
+func (c *Client) DoRequest(req *http.Request, v interface{}) error {
 	if err := c.do(req, &v); err != nil {
 		return err
 	}

--- a/perfops/run.go
+++ b/perfops/run.go
@@ -48,6 +48,8 @@ type (
 		Location string `json:"location,omitempty"`
 		// Max number of nodes
 		Limit int `json:"limit,omitempty"`
+		// IP Version
+		IPVersion int `json:"ipversion,omitempty"`
 	}
 
 	// RunResult represents the result of an MTR or ping run.
@@ -88,6 +90,7 @@ type (
 		Nodes     NodeIDs `json:"nodes,omitempty"`
 		Location  string  `json:"location,omitempty"`
 		Limit     int     `json:"limit,omitempty"`
+		IPVersion int     `json:"ipversion,omitempty""`
 	}
 
 	// DNSResolveRequest represents the parameters for a DNS resolve request.
@@ -124,13 +127,14 @@ type (
 
 	// CurlRequest represents the parameters for a curl request.
 	CurlRequest struct {
-		Target   string  `json:"target,omitempty"`
-		Head     bool    `json:"head"`
-		Insecure bool    `json:"insecure,omitempty"`
-		HTTP2    bool    `json:"http2,omitempty"`
-		Nodes    NodeIDs `json:"nodes,omitempty"`
-		Location string  `json:"location,omitempty"`
-		Limit    int     `json:"limit,omitempty"`
+		Target    string  `json:"target,omitempty"`
+		Head      bool    `json:"head"`
+		Insecure  bool    `json:"insecure,omitempty"`
+		HTTP2     bool    `json:"http2,omitempty"`
+		Nodes     NodeIDs `json:"nodes,omitempty"`
+		Location  string  `json:"location,omitempty"`
+		Limit     int     `json:"limit,omitempty"`
+		IPVersion int     `json:"ipversion,omitempty"`
 	}
 
 	argError struct {


### PR DESCRIPTION
Change adds a new --ipv6 / -6 command to all tests that support it. Unless specified, tests will explicitly be ipv4.